### PR TITLE
Include proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ const assistant = vga.VirtualGoogleAssistant.Builder()
     .create();
 ```
 
+### Proxy settings
+
+If you need to use a custom proxy, just set your `HTTP_PROXY` environment variable.
+
 # Against a Google Cloud Function file.
 
 Set the path to the Action on Google code.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@types/uuid": "^3.4.1",
     "lodash": "^4.17.4",
+    "proxy-agent": "^3.0.0",
     "uuid": "^3.1.0",
     "virtual-core": "0.0.11"
   },

--- a/src/Invoker.ts
+++ b/src/Invoker.ts
@@ -3,8 +3,10 @@ import * as https from "https";
 import * as path from "path";
 import * as URL from "url";
 
+var ProxyAgent = require('proxy-agent'); // no typescript definitions
+
 export class Invoker {
-    public static async invokeExpressFile(fileName: string, port: number, jsonRequest: any, restOfPath?:string): Promise<any> {
+    public static async invokeExpressFile(fileName: string, port: number, jsonRequest: any, restOfPath?: string): Promise<any> {
         const fullPath = path.join(process.cwd(), fileName);
 
         // Ensure the cache is removed always to be able to start the server on command
@@ -83,6 +85,10 @@ export class Invoker {
             path: url.path,
             port: url.port ? parseInt(url.port, 10) : undefined,
         };
+
+        if(process.env.http_proxy){
+            (requestOptions as any).agent = new ProxyAgent(process.env.http_proxy)
+        }
 
         return new Promise((resolve, reject) => {
             const req = httpModule.request(requestOptions, (response: any) => {


### PR DESCRIPTION
Our workspace required us to go through proxy authentication to hit an outside server (which is where our code is stored).  This PR is what allowed us to use this package through the proxy.