### PR TITLE
Fixes callback issue

### DIFF
--- a/src/Invoker.ts
+++ b/src/Invoker.ts
@@ -43,7 +43,7 @@ export class Invoker {
                 status: (code: number) => {
                     return response;
                 },
-                send: (payload: any) => {
+                send: (err: Error, payload: any) => {
                     resolve(payload);
                     return response;
                 },
@@ -56,11 +56,8 @@ export class Invoker {
                     get: () => {},
                     headers: {},
                 };
-                const googleFunctionResponse = await Promise.resolve(googleFunction(request, response));
 
-                if (googleFunctionResponse) {
-                    response.send(googleFunctionResponse);
-                }
+                return Promise.resolve(googleFunction(request, response, response.send));
             } catch (error) {
                 reject(error);
             }


### PR DESCRIPTION
This PR addresses issue #58 . When using it with a Jovo application, the Lambda class of Jovo expects a callback, which is not being sent in line 59 of the Bespoken VA package. Also, the `send` function is expecting only one parameter, the payload, and not the error object that might be null but it goes before the payload. That's why I'm always getting a null response, because the payload object is getting the error null object returned by the Jovo framework.